### PR TITLE
prerequisite for arduino core rewrite

### DIFF
--- a/cores/ddl/addon/addon_gpio.c
+++ b/cores/ddl/addon/addon_gpio.c
@@ -18,7 +18,7 @@
 en_result_t PORT_GetConfig(en_port_t port, uint16_t pin, stc_port_init_t *portConf)
 {
     DDL_ASSERT(IS_VALID_PORT(port));
-    PORT_Unlock();
+    // PORT_Unlock();
     for (uint8_t pinPos = 0u; pinPos < 16u; pinPos++)
     {
         if (pin & (1ul << pinPos))
@@ -61,7 +61,29 @@ en_result_t PORT_GetConfig(en_port_t port, uint16_t pin, stc_port_init_t *portCo
         }
     }
 
-    PORT_Lock();
+    // PORT_Lock();
+    return Ok;
+}
+
+en_result_t PORT_GetFunc(en_port_t port, uint16_t pin, en_port_func_t *funcSel, en_functional_state_t *subFuncEn)
+{
+    DDL_ASSERT(IS_VALID_PORT(port));
+    // PORT_Unlock();
+    for (uint8_t pinPos = 0u; pinPos < 16u; pinPos++)
+    {
+        if (pin & (uint16_t)(1ul << pinPos))
+        {
+            stc_port_pfsr_field_t *PFSRx = (stc_port_pfsr_field_t *)((uint32_t)(&M4_PORT->PFSRA0) + 0x40ul * port + 0x4ul * pinPos);
+
+            // main function
+            *funcSel = PFSRx->FSEL;
+
+            // subfunction enable
+            *subFuncEn = PFSRx->BFE == Enable ? Enable : Disable;
+        }
+    }
+
+    // PORT_Lock();
     return Ok;
 }
 #endif

--- a/cores/ddl/addon/addon_gpio.h
+++ b/cores/ddl/addon/addon_gpio.h
@@ -10,7 +10,15 @@ extern "C"
 {
 #endif
 
+    /**
+     * @brief inverse of PORT_Init
+    */
     en_result_t PORT_GetConfig(en_port_t port, uint16_t pin, stc_port_init_t *portConf);
+
+    /**
+     * @brief inverse of PORT_SetFunc
+    */
+    en_result_t PORT_GetFunc(en_port_t port, uint16_t pin, en_port_func_t *funcSel, en_functional_state_t *subFuncEn);
 
 #ifdef __cplusplus
 }

--- a/cores/ddl/compat/debug.c
+++ b/cores/ddl/compat/debug.c
@@ -4,4 +4,8 @@
 
 #ifdef __DEBUG
 #warning "'__DEBUG' is defined, HC32F46x debug mode is active"
+
+#ifdef __DEBUG_SHORT_FILENAMES
+#warning "'__DEBUG_SHORT_FILENAMES' is defined, short filenames are used in debug output"
+#endif
 #endif

--- a/cores/ddl/compat/newlib.c
+++ b/cores/ddl/compat/newlib.c
@@ -3,24 +3,24 @@
  * as per https://sourceware.org/newlib/libc.html#Stubs
  */
 
-int _close(int file)
+__attribute__((weak)) int _close(int file)
 {
   return -1;
 }
 
 #include <sys/stat.h>
-int _fstat(int file, struct stat *st)
+__attribute__((weak)) int _fstat(int file, struct stat *st)
 {
   st->st_mode = S_IFCHR;
   return 0;
 }
 
-int _getpid(void)
+__attribute__((weak)) int _getpid(void)
 {
   return 1;
 }
 
-int _isatty(int file)
+__attribute__((weak)) int _isatty(int file)
 {
   return 1;
 }
@@ -28,18 +28,23 @@ int _isatty(int file)
 #include <errno.h>
 #undef errno
 extern int errno;
-int _kill(int pid, int sig)
+__attribute__((weak)) int _kill(int pid, int sig)
 {
   errno = EINVAL;
   return -1;
 }
 
-int _lseek(int file, int ptr, int dir)
+__attribute__((weak)) int _lseek(int file, int ptr, int dir)
 {
   return 0;
 }
 
-int _read(int file, char *ptr, int len)
+__attribute__((weak)) int _read(int file, char *ptr, int len)
 {
   return 0;
+}
+
+__attribute__((weak)) int _write(int file, char *ptr, int len)
+{
+  return len;
 }

--- a/cores/ddl/library/inc/hc32f460_utility.h
+++ b/cores/ddl/library/inc/hc32f460_utility.h
@@ -69,9 +69,16 @@ void SysTick_Resume(void);
 /*! Ddl assert, you can add your own assert functions by implement the function
 Ddl_AssertHook definition follow the function Ddl_AssertHook declaration */
 #ifdef __DEBUG
+
+#ifdef __DEBUG_SHORT_FILENAMES
+#define __DDL_FILE__ __SOURCE_FILE_NAME__ /* use only filename */
+#else
+#define __DDL_FILE__ __FILE__ /* use file name + path */
+#endif
+
 #define DDL_ASSERT(x)                                                          \
 do{                                                                            \
-    ((x) ? (void)0 : Ddl_AssertHandler((uint8_t *)__FILE__, __LINE__));        \
+    ((x) ? (void)0 : Ddl_AssertHandler((uint8_t *)__DDL_FILE__, __LINE__));    \
 }while(0)
 /* Exported function */
 void Ddl_AssertHandler(uint8_t *file, int16_t line);

--- a/cores/ddl/library/src/hc32f460_interrupts.c
+++ b/cores/ddl/library/src/hc32f460_interrupts.c
@@ -313,7 +313,7 @@ void NMI_Handler(void)
  ** \brief Hard Fault IRQ handler
  **
  ******************************************************************************/
-void HardFault_Handler(void)
+__WEAK void HardFault_Handler(void)
 {
     HardFault_IrqHandler();
 }

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -181,3 +181,15 @@ typedef struct stc_can_init_config
     ...
 }stc_can_init_config_t;
 ```
+
+## `/cores/ddl/library/src/hc32f460_interrupts.c`
+
+arduino core handles HardFault directly and needs its own handler to be the one set in the vector table.
+to allow this, the DDL HardFault handler is defined as weak so it can be overridden by the arduino core.
+
+```cpp
+__WEAK HardFault_Handler(void)
+{
+    HardFault_IrqHandler();
+}
+```

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -28,12 +28,17 @@ The following comment is added to the top of the linker script:
 
 ### 2. Flash Start Address and Size
 
-to set the flash start address, the memory region `FLASH` is updated to use the `FLASH_START` symbol as ORIGIN and the `FLASH_SIZE` symbol as LENGTH:
+to set the flash start address, the memory region `FLASH` is updated to use the `FLASH_START` symbol as ORIGIN and the `_FLASH_SIZE_REAL` symbol as LENGTH.
+`_FLASH_SIZE_REAL` is defined as `FLASH_SIZE - FLASH_START` to correct for the flash start offset.
 
 ```cpp
+/* flash start offset reduces effective flash size available */
+_FLASH_SIZE_REAL = FLASH_SIZE - FLASH_START;
+
+/* Use contiguous memory regions for simple. */
 MEMORY
 {
-    FLASH       (rx): ORIGIN = FLASH_START, LENGTH = FLASH_SIZE
+    FLASH       (rx): ORIGIN = FLASH_START, LENGTH = _FLASH_SIZE_REAL
     OTP         (rx): ORIGIN = 0x03000C00, LENGTH = 1020
     RAM        (rwx): ORIGIN = 0x1FFF8000, LENGTH = 188K
     RET_RAM    (rwx): ORIGIN = 0x200F0000, LENGTH = 4K

--- a/docs/PATCHES.md
+++ b/docs/PATCHES.md
@@ -198,3 +198,28 @@ __WEAK HardFault_Handler(void)
     HardFault_IrqHandler();
 }
 ```
+
+## `/cores/ddl/library/inc/hc32f460_utility.h`
+
+ddl has the option to use short file names in `DDL_ASSERT` messages to save flash space.
+to allow for this, a macro `__SOURCE_FILE_NAME__` is defined by the build script and used in the `DDL_ASSERT` macro when `__DEBUG_SHORT_FILENAMES` is defined.
+
+```c
+#ifdef __DEBUG
+
+#ifdef __DEBUG_SHORT_FILENAMES
+#define __DDL_FILE__ __SOURCE_FILE_NAME__ /* use only filename */
+#else
+#define __DDL_FILE__ __FILE__ /* use file name + path */
+#endif
+
+#define DDL_ASSERT(x)                                                          \
+do{                                                                            \
+    ((x) ? (void)0 : Ddl_AssertHandler((uint8_t *)__DDL_FILE__, __LINE__));    \
+}while(0)
+/* Exported function */
+void Ddl_AssertHandler(uint8_t *file, int16_t line);
+#else
+#define DDL_ASSERT(x)                               (void)(0)
+#endif /* __DEBUG */
+```

--- a/ld/hc32f46x_param.ld
+++ b/ld/hc32f46x_param.ld
@@ -27,10 +27,13 @@
 /*  Date        2019-03-13                                                   */
 /*****************************************************************************/
 
+/* flash start offset reduces effective flash size available */
+_FLASH_SIZE_REAL = FLASH_SIZE - FLASH_START;
+
 /* Use contiguous memory regions for simple. */
 MEMORY
 {
-    FLASH       (rx): ORIGIN = FLASH_START, LENGTH = FLASH_SIZE
+    FLASH       (rx): ORIGIN = FLASH_START, LENGTH = _FLASH_SIZE_REAL
     OTP         (rx): ORIGIN = 0x03000C00, LENGTH = 1020
     RAM        (rwx): ORIGIN = 0x1FFF8000, LENGTH = 188K
     RET_RAM    (rwx): ORIGIN = 0x200F0000, LENGTH = 4K

--- a/package.json
+++ b/package.json
@@ -2,5 +2,5 @@
   "name": "framework-hc32f46x-ddl",
   "description": "HC32f46x Device Driver Library",
   "url": "https://github.com/shadow578/framework-hc32f46x-ddl",
-  "version": "0.1.0"
+  "version": "2.2.0"
 }

--- a/tools/platformio/platformio-build-ddl.py
+++ b/tools/platformio/platformio-build-ddl.py
@@ -111,7 +111,8 @@ env.Append(
 	    "_MPU_PRESENT=1",
 	    "ARM_MATH_CM4",
 	    "ARM_MATH_MATRIX_CHECK",
-	    "ARM_MATH_ROUNDING"
+	    "ARM_MATH_ROUNDING",
+        ('__SOURCE_FILE_NAME__', '\\"${SOURCE.file}\\"') # add the source file name to the defines, so it can be used in the code
     ],
 
     # c/c++ include paths

--- a/tools/platformio/platformio-build-ddl.py
+++ b/tools/platformio/platformio-build-ddl.py
@@ -126,7 +126,12 @@ def get_ld_params():
         if key in board:
             param_value = board.get(key)
             print(f"linker script param {def_name} = {param_value}")
+
+            # make available in linker script
             ld_args.append(f"-Wl,--defsym={def_name}={param_value}")
+
+            # make available in program as a define, with LD_ prefix
+            env.Append(CPPDEFINES=[f"LD_{def_name}={param_value}"])
         
     return ld_args
 env.Append(LINKFLAGS=get_ld_params())


### PR DESCRIPTION
this PR introduces changes needed for the rewrite of `framework-arduino-hc32f46x` (https://github.com/shadow578/framework-arduino-hc32f46x/pull/4)