### PR TITLE
feat: add options to configure stack and heap size

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,3 +219,20 @@ middleware not specified will be disabled by default.
 # ...
 board_build.mw.sd_card = true
 ```
+
+## Custom Stack and Heap sizes
+
+the stack and heap sizes can be configured using the `DDL_STACK_SIZE` and `DDL_HEAP_SIZE` defines.
+
+| Define           | Default | Description           |
+| ---------------- | ------- | --------------------- |
+| `DDL_STACK_SIZE` | `0x400` | the size of the stack |
+| `DDL_HEAP_SIZE`  | `0xC00` | the size of the heap  |
+
+example:
+
+```ini
+[env:myenv]
+# ...
+build_flags = -D DDL_STACK_SIZE=0x800 -D DDL_HEAP_SIZE=0x1000
+```

--- a/cores/ddl/startup/startup_hc32f460.S
+++ b/cores/ddl/startup/startup_hc32f460.S
@@ -17,6 +17,13 @@
 /*
 ;//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
 */
+#ifndef DDL_STACK_SIZE
+#define DDL_STACK_SIZE 0x00000400
+#endif
+
+#ifndef DDL_HEAP_SIZE
+#define DDL_HEAP_SIZE 0x00000C00
+#endif
 
                 .syntax     unified
                 .arch       armv7e-m
@@ -29,7 +36,7 @@
 ;  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ;</h>
 */
-                .equ        Stack_Size, 0x00000400
+                .equ        Stack_Size, DDL_STACK_SIZE
 
                 .section    .stack
                 .align      3
@@ -47,7 +54,7 @@ __StackTop:
 ;  <o> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
 ;</h>
 */
-                .equ        Heap_Size, 0x00000C00
+                .equ        Heap_Size, DDL_HEAP_SIZE
 
                 .if         Heap_Size != 0                     /* Heap is provided */
                 .section    .heap

--- a/docs/patches/README.md
+++ b/docs/patches/README.md
@@ -63,6 +63,7 @@ to allow for this, a macro `__SOURCE_FILE_NAME__` is defined by the build script
 
 ## `startup_hc32f460xc.S`
 
+### 1. `__libc_init_array` call
 the startup code needs some adjustments to work correctly with libc.
 
 <details>
@@ -71,5 +72,9 @@ the startup code needs some adjustments to work correctly with libc.
 to initialize libc, a call to `__libc_init_array` is required before `main` is called.
 
 </details>
+
+### 2. allow custom stack and heap size
+the stack and heap size are set in `startup_hc32f460xc.S`.
+by adding some defines (and `#ifdef` guards for defaults), the stack and heap size can be set from the build system using `-D DDL_STACK_SIZE=...` and `-D DDL_HEAP_SIZE=...`.
 
 [patch](./startup_hc32f460.S.patch)

--- a/docs/patches/startup_hc32f460.S.patch
+++ b/docs/patches/startup_hc32f460.S.patch
@@ -1,9 +1,41 @@
 diff --git "..\\cores\\ddl\\startup\\startup_hc32f460.S" "..\\cores\\ddl\\startup\\startup_hc32f460.S"
-index 437b1b9..990722b 100644
+index 437b1b9..b90528d 100644
 --- "..\\cores\\ddl\\startup\\startup_hc32f460.S"
 +++ "..\\cores\\ddl\\startup\\startup_hc32f460.S"
-@@ -347,6 +347,8 @@ SetSRAM3Wait:
- 
+@@ -17,6 +17,13 @@
+ /*
+ ;//-------- <<< Use Configuration Wizard in Context Menu >>> ------------------
+ */
++#ifndef DDL_STACK_SIZE
++#define DDL_STACK_SIZE 0x00000400
++#endif
++
++#ifndef DDL_HEAP_SIZE
++#define DDL_HEAP_SIZE 0x00000C00
++#endif
+
+                 .syntax     unified
+                 .arch       armv7e-m
+@@ -29,7 +36,7 @@
+ ;  <o> Stack Size (in Bytes) <0x0-0xFFFFFFFF:8>
+ ;</h>
+ */
+-                .equ        Stack_Size, 0x00000400
++                .equ        Stack_Size, DDL_STACK_SIZE
+
+                 .section    .stack
+                 .align      3
+@@ -47,7 +54,7 @@ __StackTop:
+ ;  <o> Heap Size (in Bytes) <0x0-0xFFFFFFFF:8>
+ ;</h>
+ */
+-                .equ        Heap_Size, 0x00000C00
++                .equ        Heap_Size, DDL_HEAP_SIZE
+
+                 .if         Heap_Size != 0                     /* Heap is provided */
+                 .section    .heap
+@@ -347,6 +354,8 @@ SetSRAM3Wait:
+
                  /* Call the clock system initialization function. */
                  bl          SystemInit
 +                /* call __libc_init_array before calling main */


### PR DESCRIPTION
the stack and heap sizes can be configured using the `DDL_STACK_SIZE` and `DDL_HEAP_SIZE` defines.

| Define           | Default | Description           |
| ---------------- | ------- | --------------------- |
| `DDL_STACK_SIZE` | `0x400` | the size of the stack |
| `DDL_HEAP_SIZE`  | `0xC00` | the size of the heap  |

example:

```ini
[env:myenv]
# ...
build_flags = -D DDL_STACK_SIZE=0x800 -D DDL_HEAP_SIZE=0x1000
```