### PR TITLE
Fix stack / heap size configuration options

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ see the following list for a list of available configuration options and their d
 - [Device Driver Selection](./docs/config_options/DDL_SELECTION.md)
 - [Middleware Selection](./docs/config_options/MIDDLEWARE_SELECTION.md)
 - [Heap and Stack Configuration](./docs/config_options/HEAP_AND_STACK.md)
+- [Flash size and Application Offset configuration](./docs/config_options/FLASH_SIZE.md)
 - [Boot Mode Configuration](./docs/config_options/BOOT_MODE.md)
 - [Linker Script Options](./docs/config_options/LINKER_SCRIPT.md)
 - [Custom Build Flags](./docs/config_options/BUILD_FLAGS.md)

--- a/docs/config_options/FLASH_SIZE.md
+++ b/docs/config_options/FLASH_SIZE.md
@@ -1,0 +1,19 @@
+# Flash Size and Application Offset Configuration
+
+the flash size and application offset can be configured using the `upload.maximum_size` and `upload.offset_address` options.
+
+| Option                  | Default  | Description                      |
+| ----------------------- | -------- | -------------------------------- |
+| `upload.maximum_size`   | `262144` | the size of the flash            |
+| `upload.offset_address` | `0`      | application start offset address |
+
+
+## Setting the Flash size and Application offset
+
+platformio.ini:
+```ini
+[env:myenv]
+# ...
+board_upload.maximum_size = 262144
+board_upload.offset_address = 0xC000
+```

--- a/docs/config_options/HEAP_AND_STACK.md
+++ b/docs/config_options/HEAP_AND_STACK.md
@@ -1,20 +1,21 @@
 # Heap and Stack Configuration
 
-the stack and heap sizes can be configured using the `DDL_STACK_SIZE` and `DDL_HEAP_SIZE` options.
-
-| Define           | Default | Description           |
-| ---------------- | ------- | --------------------- |
-| `DDL_STACK_SIZE` | `0x400` | the size of the stack |
-| `DDL_HEAP_SIZE`  | `0xC00` | the size of the heap  |
+the stack and heap sizes can be configured using the `board_build.stack_size` and `board_build.heap_size` options.
 
 
-## Setting the Stack and Heap Sizes
+| Option                  | Default  | Description                      |
+| ----------------------- | -------- | -------------------------------- |
+| `board_build.stack_size` | `0x400` | the size of the stack |
+| `board_build.heap_size`  | `0xC00` | the size of the heap  |
+
+
+## Setting the Flash size and Application offset
 
 platformio.ini:
 ```ini
 [env:myenv]
 # ...
-build_flags = 
-    -D DDL_STACK_SIZE=0x800 # 2KB stack
-    -D DDL_HEAP_SIZE=0x1000 # 4KB heap
+board_build.stack_size = 0x400
+board_build.heap_size = 0xC00
 ```
+

--- a/tools/platformio/platformio-build-ddl.py
+++ b/tools/platformio/platformio-build-ddl.py
@@ -298,7 +298,7 @@ env.Replace(
     # note: .data is included in both, as it's copied from flash to ram
     # this yields different sizes between ld and pio, but flash size matches the final binary size (which is what we want)
     SIZEPROGREGEXP=r"^(?:\.vectors|\.icg_sec|\.rodata|\.text|\.ARM.extab|\.ARM.exidx|\.preinit_array|\.init_array|\.fini_array|\.data)\s+(\d+).*",
-    SIZEDATAREGEXP=r"^(?:\.data|\.bss)\s+(\d+).*",
+    SIZEDATAREGEXP=r"^(?:\.data|\.bss|\.heap_stack)\s+(\d+).*",
 )
 
 


### PR DESCRIPTION
this pr fixes the way stack and heap configuration options are applied to the linker script.
this fixes #14  

additionally, the documentation is updated to reflect the changes in how heap and stack are set.
also, the configuration options for flash size and application offse are now properly documented